### PR TITLE
fix(SqlServerDataContext.Tests): версия фреймворка установлена в 4.6.1

### DIFF
--- a/SqlServerDataContext.Tests/SqlServerDataContext.Tests.csproj
+++ b/SqlServerDataContext.Tests/SqlServerDataContext.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SqlServerDataContext.Tests</RootNamespace>
     <AssemblyName>SqlServerDataContext.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -20,6 +20,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Смержите этот пул-реквест. А потом на свой комп склонируйте заново свой репозиторий, но уже в другую папку. Попробуйте открыть свежесклонированный проект и запустить тесты.